### PR TITLE
Remove temp dir name from Electrod file names

### DIFF
--- a/src/main/java/kodkod/engine/ElectrodSolver.java
+++ b/src/main/java/kodkod/engine/ElectrodSolver.java
@@ -104,7 +104,7 @@ public class ElectrodSolver implements UnboundedSolver<ExtendedOptions>,
 		File dir = new File(options.uniqueName());
 		if (!dir.exists()) dir.mkdir();
 		
-		file = dir+"/"+dir+"-"+bounds.hashCode();
+		file = dir+"/"+bounds.hashCode();
 		PrintWriter writer;
 		try {
 			writer = new PrintWriter(file+".elo");


### PR DESCRIPTION
Instead of getting .elo file names such as "long_temp_dirname/long_temp_dirname-hashCode.elo", we will get "long_temp_dirname/hashCode.elo". Related to #1 (although it does not implement the last proposed proposal).